### PR TITLE
Added the COURSES_PW environment variable to WashuasWucrslSettingsForm.php

### DIFF
--- a/modules/washuas_wucrsl/src/Form/WashuasWucrslSettingsForm.php
+++ b/modules/washuas_wucrsl/src/Form/WashuasWucrslSettingsForm.php
@@ -191,7 +191,7 @@ class WashuasWucrslSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => t('Client Password'),
       '#description' => t('Security token used to establish authenticity with the remote server.'),
-      '#default_value' => $config->get('wucrsl_prod_soap_client_pw') ?? 'password',
+      '#default_value' => $_ENV['COURSES_PW'] ?? 'password',
       '#size' => 60,
       '#maxlength' => 256,
       '#required' => FALSE,


### PR DESCRIPTION
Step 1 for adding COURSES_PW environment variable to form for repos/servers

Way to test: in the .env file, add COURSES_PW environment variable. Navigate to https://default.ddev.site/admin/config/washuas/wucrsl/settings and make sure whatever value you set that variable to = value in settings form client password