### PR TITLE
DOT-336: Update deps to wucrsl courses module

### DIFF
--- a/modules/washuas_wucrsl/src/Form/WashuasWucrslDepartmentsForm.php
+++ b/modules/washuas_wucrsl/src/Form/WashuasWucrslDepartmentsForm.php
@@ -78,7 +78,7 @@ class WashuasWucrslDepartmentsForm extends ConfigFormBase {
       '#type' => 'checkboxes',
       '#options' => $courses->getDepartmentOptions('options'),
       '#title' => $this->t('Departments to import.'),
-      '#default_value' => $config->get('wucrsl_department'),
+      '#default_value' => (empty($config->get('wucrsl_department'))) ? []:$config->get('wucrsl_department'),
      ];
 
     return parent::buildForm($form, $form_state);

--- a/modules/washuas_wucrsl/src/Form/WashuasWucrslSettingsForm.php
+++ b/modules/washuas_wucrsl/src/Form/WashuasWucrslSettingsForm.php
@@ -100,102 +100,45 @@ class WashuasWucrslSettingsForm extends ConfigFormBase {
       '#description' => t('Uncheck to always get new information from the WUCrsL feed. Check to save the results of SOAP calls in the database. Cron will always clear a WUCrsL cache older than 48 hours.'),
     );
 
-    $form['advanced']['soap_urls'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('SOAP Server Environments'),
-      '#description' => t('This is the server environment you will be using and all of the variables for each environment.'),
-      '#collapsible' => TRUE,
-      '#collapsed' => FALSE,
-    );
-
-    $form['advanced']['soap_urls']['wucrsl_soap_env'] = [
-      '#type' => 'select',
-      '#title' => $this
-        ->t('Soap URL/Environment to pull the data from.'),
-      '#options' => array(
-        'dev' => 'Development',
-        'prod' => 'Production',
-      ),
-      '#default_value' => $config->get('wucrsl_soap_env')
-        ? $config->get('wucrsl_soap_env')
-        : 'dev'
-    ];
-
-    $form['advanced']['soap_urls']['dev'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Development Settings'),
-      '#description' => t('These are the settings that apply when development is selected'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-    );
-
-    $form['advanced']['soap_urls']['dev']['wucrsl_dev_soap_url'] = array(
+    $form['advanced']['soap_urls']['wucrsl_soap_url'] = array(
       '#type' => 'textfield',
       '#title' => t('SOAP Server URL'),
-      '#description' => t('The URL to the web service provider.'),
+      '#description' => t("The URL to the web service provider, this is set in the .env file and thus read only. If this value is missing be sure to add it to the .env with: COURSES_WUCRSL_URL='client_secret'"),
       '#size' => 60,
-      '#default_value' => $config->get('wucrsl_dev_soap_url') ?? 'https://istest.wustl.edu/sis_ws_courses/SISCourses.asmx',
+      '#default_value' => $_ENV['COURSES_WUCRSL_URL'] ?? 'https://istest.wustl.edu/sis_ws_courses/SISCourses.asmx',
       '#maxlength' => 255,
       '#required' => TRUE,
+      '#attributes' => [
+        'readonly' => 'readonly',
+      ],
     );
 
-    $form['advanced']['soap_urls']['dev']['wucrsl_dev_soap_client_id'] = array(
+    $form['advanced']['soap_urls']['wucrsl_soap_client_id'] = array(
       '#type' => 'textfield',
       '#title' => t('Client UUID'),
-      '#description' => t('The long identification string used to establish an identity with the remote server.'),
-      '#default_value' => $config->get('wucrsl_dev_soap_client_id') ?? 'D31733E5-9081-479B-B536-B1C88101B5A2',
+      '#description' => t("The long identification string used to establish an identity with the remote server, this is set in the .env file and thus read only. If this value is missing be sure to add it to the .env with: COURSES_WUCRSL_ID='client_id'"),
+      '#default_value' => $_ENV['COURSES_WUCRSL_ID'] ?? 'D31733E5-9081-479B-B536-B1C88101B5A2',
       '#size' => 60,
       '#maxlength' => 256,
       '#required' => FALSE,
+      '#attributes' => [
+        'readonly' => 'readonly',
+      ],
     );
 
-    $form['advanced']['soap_urls']['dev']['wucrsl_dev_soap_client_pw'] = array(
+    $form['advanced']['soap_urls']['wucrsl_soap_client_pw'] = array(
       '#type' => 'textfield',
       '#title' => t('Client Password'),
-      '#description' => t('Security token used to establish authenticity with the remote server.'),
-      '#default_value' => $_ENV['COURSES_PW'] ?? 'password',
+      '#description' => t("Security token used to establish authenticity with the remote server, this is set in the .env file and thus read only. If this value is missing be sure to add it to the .env with: COURSES_WUCRSL_PW='client_id'"),
+      '#default_value' => $_ENV['COURSES_WUCRSL_PW'] ?? 'password',
       '#size' => 60,
       '#maxlength' => 256,
       '#required' => FALSE,
+      '#attributes' => [
+        'readonly' => 'readonly',
+      ],
     );
 
-    $form['advanced']['soap_urls']['prod'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Production Settings'),
-      '#description' => t('These are the settings that apply when production is selected'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-    );
-
-    $form['advanced']['soap_urls']['prod']['wucrsl_prod_soap_url'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Production SOAP Server URL'),
-      '#description' => t('The URL to the production web service provider.'),
-      '#size' => 60,
-      '#default_value' => $config->get('wucrsl_prod_soap_url') ?? 'https://acadinfo.wustl.edu/sis_ws_courses/siscourses.asmx',
-      '#maxlength' => 255,
-      '#required' => TRUE,
-    );
-
-    $form['advanced']['soap_urls']['prod']['wucrsl_prod_soap_client_id'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Client UUID'),
-      '#description' => t('The long identification string used to establish an identity with the remote server.'),
-      '#default_value' => $config->get('wucrsl_prod_soap_client_id') ?? 'D31733E5-9081-479B-B536-B1C88101B5A2',
-      '#size' => 60,
-      '#maxlength' => 256,
-      '#required' => FALSE,
-    );
-
-    $form['advanced']['soap_urls']['prod']['wucrsl_prod_soap_client_pw'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Client Password'),
-      '#description' => t('Security token used to establish authenticity with the remote server.'),
-      '#default_value' => $_ENV['COURSES_PW'] ?? 'password',
-      '#size' => 60,
-      '#maxlength' => 256,
-      '#required' => FALSE,
-    );
 
     return parent::buildForm($form, $form_state);
   }
@@ -213,14 +156,10 @@ class WashuasWucrslSettingsForm extends ConfigFormBase {
       ->set('wucrsl_cache_soap', $form_state->getValue('wucrsl_cache_soap'))
       ->set('wucrsl_soap_env', $form_state->getValue('wucrsl_soap_env'))
 
-      //switching things up so that you're able to keep both dev and prod settings saved
-      ->set('wucrsl_dev_soap_url', $form_state->getValue('wucrsl_dev_soap_url'))
-      ->set('wucrsl_dev_soap_client_id', $form_state->getValue('wucrsl_dev_soap_client_id'))
-      ->set('wucrsl_dev_soap_client_pw', $form_state->getValue('wucrsl_dev_soap_client_pw'))
+      ->set('wucrsl_soap_url', $form_state->getValue('wucrsl_soap_url'))
+      ->set('wucrsl_soap_client_id', $form_state->getValue('wucrsl_soap_client_id'))
+      ->set('wucrsl_soap_client_pw', $form_state->getValue('wucrsl_soap_client_pw'))
 
-      ->set('wucrsl_prod_soap_url', $form_state->getValue('wucrsl_prod_soap_url'))
-      ->set('wucrsl_prod_soap_client_id', $form_state->getValue('wucrsl_prod_soap_client_id'))
-      ->set('wucrsl_prod_soap_client_pw', $form_state->getValue('wucrsl_prod_soap_client_pw'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/modules/washuas_wucrsl/src/Services/Courses.php
+++ b/modules/washuas_wucrsl/src/Services/Courses.php
@@ -474,27 +474,25 @@ class Courses {
   /**
    * Gets the soap parameters that we will use to make our calls
    *
-   * @param string $env
-   *  the environment used to pull configuration from
-   *
    * @param string $function
    *  the soap function we will be calling
    *
    * @param string $semester
    *  the semester for which we'll pull the data
    *
+   * @param string $department
+   *   the department for which we'll pull the data
+   *
    * @return array $params
    *  the parameters we will use for soap calls
    *
    */
-  public function getSoapParameters($env,$function=null,$semester=null,$department=null): array {
+  public function getSoapParameters($function=null,$semester=null,$department=null): array {
     //this will be our return value
     $params = [];
 
-    //pull the department from the configuration or set the default to L
-    //Set the environment parameters based on the selected environment of the configuration screen
-    $params['ApplicationToken'] = $this->config->get('wucrsl_'.$env.'_soap_client_id');
-    $params['ApplicationPwd'] = $this->config->get('wucrsl_'.$env.'_soap_client_pw');
+    $params['ApplicationToken'] = $this->config->get('wucrsl_soap_client_id');
+    $params['ApplicationPwd'] = $this->config->get('wucrsl_soap_client_pw');
     //get the current semester if needed
     $current = $this->getCurrentSemester()["sort"];
     switch( $function ){
@@ -540,10 +538,9 @@ class Courses {
     //if we were not able to get the needed data from cache then we will attempt to pull it from soap
     if (empty($data)){
       //we will use this to get the associated variables from the configuration, dev is the default
-      $env = empty($this->config->get('wucrsl_soap_env')) ? 'dev' : $this->config->get('wucrsl_soap_env') ;
-      $url = $this->config->get('wucrsl_'.$env.'_soap_url');
+      $url = $this->config->get('wucrsl_soap_url');
       //get the needed parameters for this particular soap function
-      $parameters = $this->getSoapParameters($env,$soapFunction,$semester,$department);
+      $parameters = $this->getSoapParameters($soapFunction,$semester,$department);
       //run the soap function to pull the data
       $data = $soap->executeFunction($url,$parameters,$soapFunction);
       //save the data to cache

--- a/modules/washuas_wucrsl/washuas_wucrsl.module
+++ b/modules/washuas_wucrsl/washuas_wucrsl.module
@@ -11,7 +11,7 @@ use Drupal\Core\Form\FormState;
 /**
  * Implements hook_cron().
  */
-function washuas_wucrsl_cron() {
+/*function washuas_wucrsl_cron() {
   //get the batch that we will process
   $batch = \Drupal::service('washuas_wucrsl.courses')->getCoursesBatch(null,[], true);
   //get the queue that we will use to process it
@@ -20,6 +20,9 @@ function washuas_wucrsl_cron() {
   $queue->createItem($batch);
   //
 }
+
+//removed this since we're not planning on using cron for wucrsl -kenneth
+*/
 
 /**
  * Implements hook_form_views_exposed_form_alter().


### PR DESCRIPTION
This updates the washuas_wucrsl module to streamline things and get it ready for usage in d10 deps. Specifically, this moves all of the api connection values to the .env file to match the workday module. It also eliminates choosing between the two environments since we only need prod going forward. Lastly it removes the import cron job since we'll simply manual import the courses we need.

Additionally, it depends on these three variables being added to the .env:

COURSES_WUCRSL_PW='xxxx'
COURSES_WUCRSL_ID='xxxxx'
COURSES_WUCRSL_URL='https://acadinfo.wustl.edu/sis_ws_courses/siscourses.asmx'
