### PR TITLE
DOT-658 using site search is showing an "unexpected" error

### DIFF
--- a/washuas.module
+++ b/washuas.module
@@ -27,7 +27,7 @@ function washuas_rule_year_allowed_values(FieldStorageConfig $definition, Conten
 /**
  * Implements hook_views_query_alter().
  */
-function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\Sql $query) {
+function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
 
     // Skip altering preview queries in the Views UI.
     if (\Drupal::routeMatch()->getRouteName() === 'views_ui.preview') {


### PR DESCRIPTION
[DOT-658](https://washuartsci.atlassian.net/browse/DOT-658)

Marcia identified an issue that Frank Mullings confirmed about Search causing a wsod with the message, "The website encountered an unexpected error. Try again later." Frank shared:
```TypeError: washuas_views_query_alter(): Argument #2 ($query) must be of type Drupal\views\Plugin\views\query\Sql, Drupal\search_api\Plugin\views\query\SearchApiQuery given in washuas_views_query_alter() (line 30 of /code/web/modules/custom/washuas/washuas.module).```
Line 30 of the washuas.module file uses a child class, Sql, for the second parameter. Changing that to the parent class, QueryPluginBase, fixes the issue, I believe. 
This can be tested locally on a Deps build by altering line 30 of washuas.module. Before changing it, you'll get an error on search. After changing it, search will work.  

[DOT-658]: https://washuartsci.atlassian.net/browse/DOT-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ