### PR TITLE
Search issue fix

### DIFF
--- a/washuas.module
+++ b/washuas.module
@@ -27,7 +27,7 @@ function washuas_rule_year_allowed_values(FieldStorageConfig $definition, Conten
 /**
  * Implements hook_views_query_alter().
  */
-function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\Sql $query) {
+function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
 
     // Skip altering preview queries in the Views UI.
     if (\Drupal::routeMatch()->getRouteName() === 'views_ui.preview') {

--- a/washuas.module
+++ b/washuas.module
@@ -8,20 +8,21 @@
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\views\Plugin\views\query\Sql;
 
 /**
  * Implements hook_allowed_values_function().
  */
-function washuas_rule_year_allowed_values(FieldStorageConfig $definition, ContentEntityInterface $entity = NULL, $cacheable) {
-  // Available drop year values.
-  $thisyear = date('Y');
-  $i = $thisyear;
-  $options = [];
-  while ($i >= 2000) {
-    $options[$i] = $i;
-    $i--;
-  }
-  return $options;
+function washuas_rule_year_allowed_values(FieldStorageConfig $definition, ?ContentEntityInterface $entity, &$cacheable) {
+    // Available drop year values.
+    $thisyear = date('Y');
+    $i = $thisyear;
+    $options = [];
+    while ($i >= 2000) {
+        $options[$i] = $i;
+        $i--;
+    }
+    return $options;
 }
 
 /**
@@ -34,6 +35,13 @@ function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\v
         return;
     }
 
+    // This alter only applies to SQL-based views. Other query backends (e.g.
+    // Search API on the /search page) have no $relationships property and do
+    // not support raw SQL WHERE expressions, so there is nothing to do here.
+    if (!$query instanceof Sql) {
+        return;
+    }
+
     // Determine if this query involves node data, whether as base or via relationship.
     $table_aliases = [];
     foreach ($query->relationships as $alias => $info) {
@@ -43,7 +51,7 @@ function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\v
     }
 
     // If not directly found, also check the base table (in case it’s not in relationships).
-    if (!isset($table_aliases['node_field_data']) && $view->storage->get('base_table') === 'node_field_data') {
+    if (!in_array('node_field_data', $table_aliases, TRUE) && $view->storage->get('base_table') === 'node_field_data') {
         $table_aliases[] = 'node_field_data';
     }
 
@@ -59,4 +67,3 @@ function washuas_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\v
         }
     }
 }
-


### PR DESCRIPTION
### Description

The washuas_views_query_alter() implements hook_views_query_alter(), so it runs for every Views query. It assumed the query was the SQL plugin (Drupal\views\Plugin\views\query\Sql), reading $query->relationships and adding raw-SQL WHERE expressions. On Search API views (e.g. the /search page) the query plugin is SearchApiQuery, which has no $relationships property, so each request logged two PHP warnings (line 39):

- Warning: Undefined property: Drupal\search_api\Plugin\views\query\SearchApiQuery::$relationships in /var/www/html/web/modules/custom/washuas/washuas.module on line 39
- Warning: foreach() argument must be of type array|object, null given in /var/www/html/web/modules/custom/washuas/washuas.module on line 39

Reported on a deps site's /search page (/search?search_api_views_fulltext=…).

### Changes

- Guard the hook with `instanceof Sql` and return early for non-SQL query backends. The WHERE expressions it adds are SQL-only and meaningless against a Search API index, so search views are skipped entirely.
- Fix the base-table dedupe: `$table_aliases` is a numerically-indexed list, so `isset($table_aliases['node_field_data'])` never matched; use `in_array(..., TRUE)` to avoid adding `node_field_data` (and a duplicate WHERE) twice.
- Modernize `washuas_rule_year_allowed_values()` signature to match core's `callback_allowed_values_function` contract (?ContentEntityInterface $entity, by-reference &$cacheable; explicit-nullable for PHP 8.4).

### Testing

- Stand up local deps in DDEV from a Live pantheon-sync. (you can make warnings loud: ddev drush config:set system.logging error_level verbose -y && ddev drush cr)
- Before: load /search?search_api_views_fulltext=2025 → two warnings in Reports → Recent log messages.
- Apply fix: replace web/modules/custom/washuas/washuas.module with this PR's version, then ddev drush cr. (File is gitignored in deps, so it won't dirty the tree.)
- After: run the search again → no SearchApiQuery::$relationships / foreach() warnings; search renders results.
- Regression (SQL views): anonymous user → private nodes stay hidden in listings; user with access private content → private nodes appear.

Note: the search results page is page-cached by URL for anonymous users. Between the before/after runs, vary the term (e.g. 2025 then 2026), ddev drush cr, or test while logged in — otherwise a cached page can produce a false "no warning" pass.

### Rollback
Revert the tag; deps/artsci stay pinned to the prior washuas release (v1.2.8).